### PR TITLE
Revert "⬆️ Upgrade container image cloudflare/cloudflared to v2023.7.3"

### DIFF
--- a/kubernetes/manifests/gitops/flux-system/cloudflare-tunnel.yaml
+++ b/kubernetes/manifests/gitops/flux-system/cloudflare-tunnel.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: cloudflared
-          image: cloudflare/cloudflared:2023.7.3
+          image: cloudflare/cloudflared:2022.3.0
           args:
             - tunnel
             - --config


### PR DESCRIPTION
Reverts charlie-haley/home-infra#753

Receiving an error with the latest version, need to add capabilities for the pod
```
2023-08-01T07:59:48Z WRN The user running cloudflared process has a GID (group ID) that is not within ping_group_range. You might need to add that user to a group within that range, or instead update the range to encompass a group the user is already in by modifying /proc/sys/net/ipv4/ping_group_range. Otherwise cloudflared will not be able to ping this network error="Group ID 65532 is not between ping group 1 to 0"
2023-08-01T07:59:48Z WRN ICMP proxy feature is disabled error="cannot create ICMPv4 proxy: Group ID 65532 is not between ping group 1 to 0 nor ICMPv6 proxy: socket: permission denied"
```